### PR TITLE
修复科学家制造蓝图实际数量和日志显示数量不符合的bug

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -2571,7 +2571,7 @@ var run = function() {
             if (!this.canCraft(name, amount)) return;
 
             var craft = this.getCraft(name);
-            var ratio = game.getResCraftRatio(craft);
+            var ratio = game.getResCraftRatio(craft.name);
 
             game.craft(craft.name, amount);
 
@@ -2620,7 +2620,7 @@ var run = function() {
             var materials = this.getMaterials(name);
 
             var craft = this.getCraft(name);
-            var ratio = game.getResCraftRatio(craft);
+            var ratio = game.getResCraftRatio(craft.name);
             var trigger = options.auto.craft.trigger;
             var optionVal = options.auto.options.enabled && options.auto.options.items.shipOverride.enabled;
 
@@ -2628,12 +2628,12 @@ var run = function() {
             if (!materials) return 0;
 
             if (name==='steel' && limited) {
-                var plateRatio=game.getResCraftRatio(this.getCraft('plate'));
+                var plateRatio=game.getResCraftRatio('plate');
                 if (this.getValueAvailable('plate')/this.getValueAvailable('steel') < ((plateRatio+1)/125)/((ratio+1)/100)) {
                     return 0;
                 }
             } else if (name==='plate' && limited) {
-                var steelRatio=game.getResCraftRatio(this.getCraft('steel'));
+                var steelRatio=game.getResCraftRatio('steel');
                 if (game.getResourcePerTick('coal', true) > 0) {
                     if (this.getValueAvailable('plate')/this.getValueAvailable('steel') > ((ratio+1)/125)/((steelRatio+1)/100)) {
                         var ironInTime = ((this.getResource('coal').maxValue*trigger - this.getValue('coal'))/game.getResourcePerTick('coal', true))*Math.max(game.getResourcePerTick('iron', true), 0);


### PR DESCRIPTION
game.getResCraftRatio()函数传入参数类型应该为字符串。在科学家的一些调用中，传入的参数为craft，导致getResCraftRatio只会返回基础的radio，即工坊、领袖等。对于蓝图而言，传入参数类型错误导致无法获得cad系统加成的那部分radio。不过不影响最终生产数量，只影响日志的记录数量。